### PR TITLE
Remove tbody on attribute selectors, which isn't present in raw source

### DIFF
--- a/profile/attributes.json
+++ b/profile/attributes.json
@@ -1,39 +1,39 @@
 {
     "STRENGTH": {
-        "selector": "table.character__param__list:nth-child(2) > tbody:nth-child(1) > tr:nth-child(1) > td:nth-child(2)"
+        "selector": "table.character__param__list:nth-child(2) > tr:nth-child(1) > td:nth-child(2)"
     },
     "DEXTERITY": {
-        "selector": "table.character__param__list:nth-child(2) > tbody:nth-child(1) > tr:nth-child(2) > td:nth-child(2)"
+        "selector": "table.character__param__list:nth-child(2) > tr:nth-child(2) > td:nth-child(2)"
     },
     "VITALITY": {
-        "selector": "table.character__param__list:nth-child(2) > tbody:nth-child(1) > tr:nth-child(3) > td:nth-child(2)"
+        "selector": "table.character__param__list:nth-child(2) > tr:nth-child(3) > td:nth-child(2)"
     },
     "INTELLIGENCE": {
-        "selector": "table.character__param__list:nth-child(2) > tbody:nth-child(1) > tr:nth-child(4) > td:nth-child(2)"
+        "selector": "table.character__param__list:nth-child(2) > tr:nth-child(4) > td:nth-child(2)"
     },
     "MIND": {
-        "selector": "table.character__param__list:nth-child(2) > tbody:nth-child(1) > tr:nth-child(5) > td:nth-child(2)"
+        "selector": "table.character__param__list:nth-child(2) > tr:nth-child(5) > td:nth-child(2)"
     },
     "CRITICAL_HIT_RATE": {
-        "selector": "table.character__param__list:nth-child(4) > tbody:nth-child(1) > tr:nth-child(1) > td:nth-child(2)"
+        "selector": "table.character__param__list:nth-child(4) > tr:nth-child(1) > td:nth-child(2)"
     },
     "DETERMINATION": {
-        "selector": "table.character__param__list:nth-child(4) > tbody:nth-child(1) > tr:nth-child(2) > td:nth-child(2)"
+        "selector": "table.character__param__list:nth-child(4) > tr:nth-child(2) > td:nth-child(2)"
     },
     "DIRECT_HIT_RATE": {
-        "selector": "table.character__param__list:nth-child(4) > tbody:nth-child(1) > tr:nth-child(3) > td:nth-child(2)"
+        "selector": "table.character__param__list:nth-child(4) > tr:nth-child(3) > td:nth-child(2)"
     },
     "DEFENSE": {
-        "selector": "table.character__param__list:nth-child(6) > tbody:nth-child(1) > tr:nth-child(1) > td:nth-child(2)"
+        "selector": "table.character__param__list:nth-child(6) > tr:nth-child(1) > td:nth-child(2)"
     },
     "MAGIC_DEFENSE": {
-        "selector": "table.character__param__list:nth-child(6) > tbody:nth-child(1) > tr:nth-child(2) > td:nth-child(2)"
+        "selector": "table.character__param__list:nth-child(6) > tr:nth-child(2) > td:nth-child(2)"
     },
     "ATTACK_POWER": {
-        "selector": "table.character__param__list:nth-child(8) > tbody:nth-child(1) > tr:nth-child(1) > td:nth-child(2)"
+        "selector": "table.character__param__list:nth-child(8) > tr:nth-child(1) > td:nth-child(2)"
     },
     "SKILL_SPEED": {
-        "selector": "table.character__param__list:nth-child(8) > tbody:nth-child(1) > tr:nth-child(2) > td:nth-child(2)"
+        "selector": "table.character__param__list:nth-child(8) > tr:nth-child(2) > td:nth-child(2)"
     },
     "ATTACK_MAGIC_POTENCY": {
         "selector": "table.character__param__list:nth-child(10) > tbody:nth-child(1) > tr:nth-child(1) > td:nth-child(2)"


### PR DESCRIPTION
Looks like Chrome / Firefox browsers insert tbody elements, which isn't present in the raw source. This *breaks* selection on browsers, but *fixes* it on anything parsing the raw html.